### PR TITLE
Update typography to modern tech fonts

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,7 +3,27 @@
 @tailwind utilities;
 
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-space-grotesk), "Inter", "SF Pro Display", -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
+  text-rendering: optimizeLegibility;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-space-grotesk), "Inter", "SF Pro Display", -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
+  letter-spacing: -0.01em;
+}
+
+code,
+pre,
+kbd,
+samp {
+  font-family: var(--font-plex-mono), "JetBrains Mono", "Fira Code", monospace;
 }
 
 @layer base {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,17 +1,21 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Space_Grotesk, IBM_Plex_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/react";
 import "./globals.css";
 import Navbar from "@/components/section/Navbar";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const spaceGrotesk = Space_Grotesk({
   subsets: ["latin"],
+  variable: "--font-space-grotesk",
+  display: "swap",
+  weight: ["400", "500", "600", "700"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const plexMono = IBM_Plex_Mono({
   subsets: ["latin"],
+  variable: "--font-plex-mono",
+  display: "swap",
+  weight: ["400", "500", "600"],
 });
 
 export const metadata: Metadata = {
@@ -28,7 +32,7 @@ export default function RootLayout({
   return (
     <html lang='en'>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${spaceGrotesk.variable} ${plexMono.variable} antialiased`}
       >
         <Navbar />
         <div className="min-vh-screen">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,8 +8,8 @@ export default {
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-  	extend: {
-  		colors: {
+        extend: {
+                colors: {
   			background: 'hsl(var(--background))',
   			foreground: 'hsl(var(--foreground))',
   			card: {
@@ -55,8 +55,34 @@ export default {
   			'color-3': 'hsl(var(--color-3))',
   			'color-4': 'hsl(var(--color-4))',
   			'color-5': 'hsl(var(--color-5))'
-  		},
-  		borderRadius: {
+                },
+                fontFamily: {
+                        sans: [
+                                'var(--font-space-grotesk)',
+                                'Inter',
+                                'SF Pro Display',
+                                '-apple-system',
+                                'BlinkMacSystemFont',
+                                'Segoe UI',
+                                'sans-serif',
+                        ],
+                        display: [
+                                'var(--font-space-grotesk)',
+                                'Inter',
+                                'SF Pro Display',
+                                '-apple-system',
+                                'BlinkMacSystemFont',
+                                'Segoe UI',
+                                'sans-serif',
+                        ],
+                        mono: [
+                                'var(--font-plex-mono)',
+                                'JetBrains Mono',
+                                'Fira Code',
+                                'monospace',
+                        ],
+                },
+                borderRadius: {
   			lg: 'var(--radius)',
   			md: 'calc(var(--radius) - 2px)',
   			sm: 'calc(var(--radius) - 4px)'


### PR DESCRIPTION
## Summary
- replace Geist fonts with Space Grotesk and IBM Plex Mono for a more technical aesthetic
- apply the new font stack globally for body text, headings, and monospaced elements
- expose the font families in Tailwind for use across components

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc19c387108324b75309a82b90528e