### PR TITLE
Add PHP city-specific landing pages for major French hubs

### DIFF
--- a/app/developpeur-web/[slug]/page.tsx
+++ b/app/developpeur-web/[slug]/page.tsx
@@ -76,12 +76,19 @@ export default async function TechnologyPage({ params }: {
         "@type": "ProfessionalService",
         name: page.heroTitle,
         description: page.seoDescription,
-        areaServed: {
-            "@type": "AdministrativeArea",
-            name: "France",
-        },
+        areaServed: page.city
+            ? {
+                  "@type": "City",
+                  name: page.city,
+              }
+            : {
+                  "@type": "AdministrativeArea",
+                  name: "France",
+              },
         url: `${SITE_URL}/developpeur-web/${page.slug}`,
-        serviceType: `Développement ${page.technology}`,
+        serviceType: page.city
+            ? `Développement ${page.technology} à ${page.city}`
+            : `Développement ${page.technology}`,
         provider: {
             "@type": "Person",
             name: "Dylan Germann",

--- a/lib/technology-pages.ts
+++ b/lib/technology-pages.ts
@@ -1,6 +1,7 @@
 export type TechnologyPageContent = {
     slug: string;
     technology: string;
+    city?: string;
     heroTitle: string;
     heroSubtitle: string;
     heroDescription: string;
@@ -104,6 +105,946 @@ export const technologyPages: TechnologyPageContent[] = [
                 question: "Pouvez-vous collaborer avec une équipe interne ?",
                 answer:
                     "Absolument. Je m'intègre à vos rituels (Scrum, Kanban), je documente chaque décision et je facilite le transfert de connaissances.",
+            },
+        ],
+    },
+    {
+        slug: "php-paris",
+        technology: "PHP",
+        city: "Paris",
+        heroTitle: "Développeur web PHP freelance à Paris",
+        heroSubtitle: "Livrez des plateformes PHP ambitieuses pour vos équipes parisiennes",
+        heroDescription:
+            "Au cœur de l'écosystème tech parisien, j'accompagne startups, scale-ups et ETI pour sécuriser leurs produits PHP : audits flash, refontes agiles et coaching d'équipes produit.",
+        seoDescription:
+            "Développeur web PHP freelance à Paris : création d'applications métier, API performantes, TMA et coaching pour startups et grands comptes parisiens.",
+        keywords: [
+            "développeur PHP Paris",
+            "freelance PHP Paris",
+            "développeur web PHP Paris",
+            "expert PHP Paris",
+            "consultant PHP Paris",
+        ],
+        highlights: [
+            {
+                title: "Expertise scale-up parisiennes",
+                description:
+                    "Roadmap produit cadrée, priorisation data-driven et sprints alignés avec vos squads pour délivrer vite et bien.",
+            },
+            {
+                title: "Delivery sécurisé",
+                description:
+                    "CI/CD, tests automatisés et observabilité pour absorber les pics de trafic marketing et media.",
+            },
+            {
+                title: "Collaboration hybride",
+                description:
+                    "Présence dans vos bureaux parisiens ou travail à distance synchrone avec vos équipes internationales.",
+            },
+        ],
+        services: [
+            {
+                title: "Kick-off produit en 10 jours",
+                description:
+                    "Ateliers à Station F ou dans vos locaux, cadrage fonctionnel, architecture PHP et roadmap de livraison.",
+            },
+            {
+                title: "Développement d'API fintech",
+                description:
+                    "Sécurisation des flux, conformité RGPD et optimisation des temps de réponse pour vos services financiers.",
+            },
+            {
+                title: "TMA premium",
+                description:
+                    "Support 24/5, monitoring et mises à jour régulières pour vos plateformes critiques parisiennes.",
+            },
+        ],
+        results: [
+            {
+                value: "+45%",
+                label: "de transactions",
+                description: "grâce à une API PHP optimisée pour une fintech parisienne.",
+            },
+            {
+                value: "10 jours",
+                label: "pour livrer un POC",
+                description: "avec une équipe produit basée dans le Sentier.",
+            },
+            {
+                value: "99,9%",
+                label: "de disponibilité",
+                description: "atteinte sur une plateforme média à très fort trafic.",
+            },
+        ],
+        testimonials: [
+            {
+                quote:
+                    "Dylan a cadré notre refonte PHP en un mois. Les équipes Produit et Data parisiennes ont gagné un cycle d'avance sur la roadmap.",
+                author: "Sophie R.",
+                role: "CTO, fintech parisienne",
+            },
+        ],
+        faq: [
+            {
+                question: "Pouvez-vous intervenir dans nos bureaux parisiens ?",
+                answer:
+                    "Oui, j'organise des rituels sur site dans vos locaux (WeWork, Station F, grands comptes) et maintiens un suivi quotidien à distance.",
+            },
+            {
+                question: "Gérez-vous la scalabilité pendant les pics média ?",
+                answer:
+                    "Je dimensionne l'infrastructure PHP, mets en place du caching (Redis, CDN) et des tests de charge pour absorber vos campagnes marketing.",
+            },
+            {
+                question: "Êtes-vous à l'aise avec nos exigences sécurité et conformité ?",
+                answer:
+                    "Oui, je maîtrise les enjeux RGPD, PCI DSS et cybersécurité, et je travaille avec vos équipes compliance pour documenter chaque décision.",
+            },
+        ],
+    },
+    {
+        slug: "php-lyon",
+        technology: "PHP",
+        city: "Lyon",
+        heroTitle: "Développeur web PHP freelance à Lyon",
+        heroSubtitle: "Optimisez vos applications PHP pour la métropole lyonnaise",
+        heroDescription:
+            "Installé à Lyon, j'accompagne les acteurs industriels, santé et retail pour moderniser leurs plateformes PHP : audit express, refonte maîtrisée et accompagnement des équipes locales.",
+        seoDescription:
+            "Développeur web PHP freelance à Lyon : refonte d'applications métier, intégrations ERP/GPAO, API performantes et maintenance pour entreprises lyonnaises.",
+        keywords: [
+            "développeur PHP Lyon",
+            "freelance PHP Lyon",
+            "développeur web PHP Lyon",
+            "expert PHP Lyon",
+            "consultant PHP Lyon",
+        ],
+        highlights: [
+            {
+                title: "Proximité avec l'écosystème lyonnais",
+                description:
+                    "Rendez-vous réguliers à la Part-Dieu ou Confluence, travail main dans la main avec vos équipes produit.",
+            },
+            {
+                title: "Expertise secteurs régaliens",
+                description:
+                    "Manufacturing, biotech, santé : j'adapte vos outils PHP aux exigences qualité et réglementaires locales.",
+            },
+            {
+                title: "Croissance maîtrisée",
+                description:
+                    "Coaching agile, suivi des KPIs et amélioration continue pour vos plateformes en scale-up.",
+            },
+        ],
+        services: [
+            {
+                title: "Refonte d'applications métier",
+                description:
+                    "Audit technique, ateliers sur site à Lyon et nouvelle architecture PHP prête pour la croissance.",
+            },
+            {
+                title: "Intégrations ERP & GPAO",
+                description:
+                    "Connecteurs Sage, Microsoft Dynamics ou SAP pour fluidifier vos processus industriels.",
+            },
+            {
+                title: "Coaching d'équipe PHP",
+                description:
+                    "Formations sur vos standards, pair-programming et montée en compétence de vos développeurs lyonnais.",
+            },
+        ],
+        results: [
+            {
+                value: "+30%",
+                label: "de productivité",
+                description: "suite à l'automatisation des workflows d'une PME lyonnaise.",
+            },
+            {
+                value: "8 semaines",
+                label: "pour lancer un portail B2B",
+                description: "au service d'un acteur industriel de la vallée du Rhône.",
+            },
+            {
+                value: "100%",
+                label: "d'adoption",
+                description: "par les équipes support après une refonte UX complète.",
+            },
+        ],
+        testimonials: [
+            {
+                quote:
+                    "Nous avions un legacy PHP difficile à faire évoluer. Dylan a piloté la migration sans interruption de service et a formé notre équipe lyonnaise.",
+                author: "Marc L.",
+                role: "DSI, groupe industriel lyonnais",
+            },
+        ],
+        faq: [
+            {
+                question: "Vous déplacez-vous sur Lyon et sa région ?",
+                answer:
+                    "Oui, j'interviens sur site dans toute la métropole (Villeurbanne, Vénissieux, Meyzieu) pour des ateliers ou des sprints intensifs.",
+            },
+            {
+                question: "Pouvez-vous travailler avec nos partenaires locaux ?",
+                answer:
+                    "Je coordonne les intégrations avec vos prestataires (hébergeurs, SSII, studios design) pour sécuriser chaque livraison.",
+            },
+            {
+                question: "Accompagnez-vous la montée en compétences interne ?",
+                answer:
+                    "Oui, je propose coaching, revues de code et documentation pour rendre vos équipes PHP autonomes rapidement.",
+            },
+        ],
+    },
+    {
+        slug: "php-marseille",
+        technology: "PHP",
+        city: "Marseille",
+        heroTitle: "Développeur web PHP freelance à Marseille",
+        heroSubtitle: "Des plateformes PHP fiables pour l'économie marseillaise",
+        heroDescription:
+            "Depuis Marseille, j'accompagne les acteurs du port, du tourisme et du e-commerce méditerranéen pour bâtir des solutions PHP robustes, sécurisées et prêtes à scaler.",
+        seoDescription:
+            "Développeur web PHP freelance à Marseille : création d'applications sur mesure, API logistique, maintenance et optimisation pour entreprises marseillaises.",
+        keywords: [
+            "développeur PHP Marseille",
+            "freelance PHP Marseille",
+            "développeur web PHP Marseille",
+            "expert PHP Marseille",
+            "consultant PHP Marseille",
+        ],
+        highlights: [
+            {
+                title: "Expertise logistique & portuaire",
+                description:
+                    "Synchronisation avec vos SI portuaires, traçabilité en temps réel et reporting sur mesure.",
+            },
+            {
+                title: "Performance e-commerce",
+                description:
+                    "Optimisation des tunnels d'achat, gestion des pics saisonniers et intégration marketplace.",
+            },
+            {
+                title: "Sécurité renforcée",
+                description:
+                    "Protection des API, audits OWASP et durcissement serveur pour vos données sensibles.",
+            },
+        ],
+        services: [
+            {
+                title: "Plateformes logistiques PHP",
+                description:
+                    "Gestion des flux, interfaces transporteurs et automatisation documentaire pour le port de Marseille.",
+            },
+            {
+                title: "Optimisation e-commerce",
+                description:
+                    "Amélioration des performances Prestashop/Laravel et intégration CRM pour booster vos ventes.",
+            },
+            {
+                title: "Maintenance évolutive",
+                description:
+                    "Suivi mensuel, correctifs rapides et nouvelles features pour vos sites touristiques et culturels.",
+            },
+        ],
+        results: [
+            {
+                value: "-35%",
+                label: "de coûts opérationnels",
+                description: "grâce à la digitalisation PHP d'un transit portuaire.",
+            },
+            {
+                value: "+22%",
+                label: "de conversions",
+                description: "après l'optimisation d'une boutique en ligne marseillaise.",
+            },
+            {
+                value: "48h",
+                label: "pour déployer",
+                description: "des correctifs critiques suite à des incidents sécurité.",
+            },
+        ],
+        testimonials: [
+            {
+                quote:
+                    "Dylan comprend nos enjeux portuaires. Sa solution PHP a fluidifié nos échanges de données avec les transitaires méditerranéens.",
+                author: "Nadia G.",
+                role: "Responsable SI, opérateur logistique marseillais",
+            },
+        ],
+        faq: [
+            {
+                question: "Intervenez-vous sur site dans nos entrepôts ?",
+                answer:
+                    "Oui, je me déplace sur Marseille, Fos-sur-Mer et Aubagne pour cadrer les besoins avec vos équipes terrain.",
+            },
+            {
+                question: "Pouvez-vous gérer nos contraintes multilingues ?",
+                answer:
+                    "Je conçois des back-offices PHP multilingues adaptés aux flux internationaux et aux équipes bilingues.",
+            },
+            {
+                question: "Comment sécurisez-vous nos échanges de données ?",
+                answer:
+                    "Mise en place de tunnels chiffrés, journalisation et monitoring 24/7 pour protéger vos données sensibles.",
+            },
+        ],
+    },
+    {
+        slug: "php-toulouse",
+        technology: "PHP",
+        city: "Toulouse",
+        heroTitle: "Développeur web PHP freelance à Toulouse",
+        heroSubtitle: "Accélérez vos projets PHP dans l'écosystème toulousain",
+        heroDescription:
+            "Basé à Toulouse, j'aide les acteurs aéronautiques, spatiaux et edtech à livrer des plateformes PHP fiables, scalables et intégrées à leurs outils métiers.",
+        seoDescription:
+            "Développeur web PHP freelance à Toulouse : applications métier, API industrielles, maintenance et coaching agile pour entreprises de la région.",
+        keywords: [
+            "développeur PHP Toulouse",
+            "freelance PHP Toulouse",
+            "développeur web PHP Toulouse",
+            "expert PHP Toulouse",
+            "consultant PHP Toulouse",
+        ],
+        highlights: [
+            {
+                title: "Culture engineering",
+                description:
+                    "Process qualité inspirés de l'aéronautique : revues de code strictes, tests automatisés et traçabilité.",
+            },
+            {
+                title: "Interopérabilité SI",
+                description:
+                    "Connexion à vos PLM, ERP industriels et outils data science pour des flux fiables.",
+            },
+            {
+                title: "Collaboration agile",
+                description:
+                    "Scrum ou Kanban, rituels partagés avec vos équipes produits basées à Labège ou Blagnac.",
+            },
+        ],
+        services: [
+            {
+                title: "Portails partenaires aéronautiques",
+                description:
+                    "Gestion des droits, traçabilité et sécurité renforcée pour vos sous-traitants et fournisseurs.",
+            },
+            {
+                title: "API temps réel",
+                description:
+                    "PHP + websockets pour suivre vos opérations et synchroniser vos jumeaux numériques.",
+            },
+            {
+                title: "Formation des équipes",
+                description:
+                    "Sessions dédiées à vos développeurs et product owners pour accélérer la livraison.",
+            },
+        ],
+        results: [
+            {
+                value: "12 semaines",
+                label: "pour livrer un portail",
+                description: "connecté à un SI industriel toulousain.",
+            },
+            {
+                value: "+28%",
+                label: "de rapidité de release",
+                description: "grâce à une pipeline CI/CD industrialisée.",
+            },
+            {
+                value: "0 incident",
+                label: "en production",
+                description: "durant les 6 premiers mois de mise en ligne.",
+            },
+        ],
+        testimonials: [
+            {
+                quote:
+                    "Grâce à Dylan, notre plateforme PHP s'interface parfaitement avec nos outils industriels et respecte nos standards qualité.",
+                author: "Isabelle P.",
+                role: "Product Manager, groupe aéronautique toulousain",
+            },
+        ],
+        faq: [
+            {
+                question: "Pouvez-vous travailler en environnement sécurisé ?",
+                answer:
+                    "Oui, je respecte vos procédures d'accès (badge, VPN, bastion) et j'utilise des environnements isolés pour vos données sensibles.",
+            },
+            {
+                question: "Intervenez-vous en anglais ?",
+                answer:
+                    "Je collabore quotidiennement avec des équipes internationales et j'anime les rituels en français ou anglais.",
+            },
+            {
+                question: "Gérez-vous nos contraintes de planification ?",
+                answer:
+                    "Je construis un plan projet aligné avec vos jalons industriels et vos cycles de certification.",
+            },
+        ],
+    },
+    {
+        slug: "php-bordeaux",
+        technology: "PHP",
+        city: "Bordeaux",
+        heroTitle: "Développeur web PHP freelance à Bordeaux",
+        heroSubtitle: "Boostez vos projets PHP dans la métropole bordelaise",
+        heroDescription:
+            "À Bordeaux, j'accompagne les acteurs du vin, du tourisme et des services numériques pour créer des expériences PHP performantes et orientées business.",
+        seoDescription:
+            "Développeur web PHP freelance à Bordeaux : création d'applications sur mesure, connecteurs e-commerce, maintenance et optimisation pour entreprises girondines.",
+        keywords: [
+            "développeur PHP Bordeaux",
+            "freelance PHP Bordeaux",
+            "développeur web PHP Bordeaux",
+            "expert PHP Bordeaux",
+            "consultant PHP Bordeaux",
+        ],
+        highlights: [
+            {
+                title: "Expérience e-commerce & tourisme",
+                description:
+                    "Gestion des réservations, billetterie et ventes omnicanales pour vos domaines viticoles et musées.",
+            },
+            {
+                title: "Approche data-driven",
+                description:
+                    "Dashboards, KPIs et automatisation marketing pour piloter vos conversions.",
+            },
+            {
+                title: "Équipe locale renforcée",
+                description:
+                    "Ateliers réguliers aux Chartrons ou à Darwin pour aligner produit, marketing et technique.",
+            },
+        ],
+        services: [
+            {
+                title: "Plateformes de réservation",
+                description:
+                    "Systèmes PHP pour visites de châteaux, événements et expériences oenotouristiques.",
+            },
+            {
+                title: "Connecteurs marketplace",
+                description:
+                    "Intégration avec Shopify, Amazon ou plateformes locales pour centraliser vos commandes.",
+            },
+            {
+                title: "Maintenance proactive",
+                description:
+                    "Veille technologique, mises à jour et monitoring pour vos plateformes SaaS bordelaises.",
+            },
+        ],
+        results: [
+            {
+                value: "+32%",
+                label: "de réservations",
+                description: "après la refonte d'une plateforme touristique.",
+            },
+            {
+                value: "6 semaines",
+                label: "pour lancer un tunnel de vente",
+                description: "pour un domaine viticole girondin.",
+            },
+            {
+                value: "4x",
+                label: "moins de maintenance",
+                description: "grâce à l'automatisation et aux tests end-to-end.",
+            },
+        ],
+        testimonials: [
+            {
+                quote:
+                    "Dylan a su traduire nos enjeux marketing en un back-office PHP simple à piloter et relié à nos outils commerciaux.",
+                author: "Claire V.",
+                role: "Responsable digital, groupe oenotouristique bordelais",
+            },
+        ],
+        faq: [
+            {
+                question: "Pouvez-vous travailler avec notre agence locale ?",
+                answer:
+                    "Oui, je co-construis la roadmap technique avec vos partenaires marketing ou design basés à Bordeaux.",
+            },
+            {
+                question: "Gérez-vous la saisonnalité de nos ventes ?",
+                answer:
+                    "Je dimensionne l'infrastructure PHP pour absorber les pics et je mets en place du caching intelligent.",
+            },
+            {
+                question: "Proposez-vous un support bilingue ?",
+                answer:
+                    "Je peux fournir interfaces et documentation en français et anglais pour vos équipes internationales.",
+            },
+        ],
+    },
+    {
+        slug: "php-lille",
+        technology: "PHP",
+        city: "Lille",
+        heroTitle: "Développeur web PHP freelance à Lille",
+        heroSubtitle: "Accélérez vos projets PHP retail et e-commerce dans le Nord",
+        heroDescription:
+            "Basé à Lille, j'accompagne retailers, pure players et services B2B pour bâtir des solutions PHP résilientes, omnicanales et orientées performance.",
+        seoDescription:
+            "Développeur web PHP freelance à Lille : refonte e-commerce, PIM/ERP, APIs logistiques et maintenance pour entreprises du Nord.",
+        keywords: [
+            "développeur PHP Lille",
+            "freelance PHP Lille",
+            "développeur web PHP Lille",
+            "expert PHP Lille",
+            "consultant PHP Lille",
+        ],
+        highlights: [
+            {
+                title: "Culture retail & supply chain",
+                description:
+                    "Synchronisation avec vos PIM, ERP et outils logistiques pour offrir une expérience unifiée.",
+            },
+            {
+                title: "Omnicanal sans friction",
+                description:
+                    "Click & collect, ship-from-store et CRM intégrés pour vos clients nordistes.",
+            },
+            {
+                title: "Industrialisation de la qualité",
+                description:
+                    "Tests automatisés, revue de code et monitoring pour des releases sereines.",
+            },
+        ],
+        services: [
+            {
+                title: "Refonte e-commerce Magento/Laravel",
+                description:
+                    "Optimisation des performances, SEO technique et intégrations marketing pour vos enseignes.",
+            },
+            {
+                title: "Portails B2B",
+                description:
+                    "Accès distributeurs, catalogue personnalisé et gestion des stocks en temps réel.",
+            },
+            {
+                title: "Support continu",
+                description:
+                    "Supervision, correctifs urgents et évolutions régulières avec vos équipes digitales lilloises.",
+            },
+        ],
+        results: [
+            {
+                value: "+38%",
+                label: "de panier moyen",
+                description: "après l'optimisation d'un parcours omnicanal.",
+            },
+            {
+                value: "3x",
+                label: "plus rapide",
+                description: "pour déployer de nouvelles collections grâce à l'automatisation PHP.",
+            },
+            {
+                value: "24h",
+                label: "pour corriger",
+                description: "des incidents critiques durant les soldes.",
+            },
+        ],
+        testimonials: [
+            {
+                quote:
+                    "Dylan connaît parfaitement nos enjeux retail. Nos ventes en ligne ont bondi tout en réduisant les tickets SAV.",
+                author: "Emilie S.",
+                role: "Directrice e-commerce, enseigne lilloise",
+            },
+        ],
+        faq: [
+            {
+                question: "Travaillez-vous avec nos équipes magasins ?",
+                answer:
+                    "Oui, je co-construis les parcours omnicanaux avec vos responsables digitaux et retail.",
+            },
+            {
+                question: "Pouvez-vous gérer nos pics de trafic ?",
+                answer:
+                    "Je mets en place du scaling horizontal, du caching et des tests de charge pour sécuriser vos pics saisonniers.",
+            },
+            {
+                question: "Accompagnez-vous la formation interne ?",
+                answer:
+                    "Oui, j'anime des ateliers pour vos développeurs et votre support technique afin d'assurer la continuité.",
+            },
+        ],
+    },
+    {
+        slug: "php-nantes",
+        technology: "PHP",
+        city: "Nantes",
+        heroTitle: "Développeur web PHP freelance à Nantes",
+        heroSubtitle: "Des projets PHP durables pour l'ouest",
+        heroDescription:
+            "À Nantes, j'aide les entreprises de l'industrie, de l'IoT et des services numériques à livrer des applications PHP pérennes, sécurisées et orientées utilisateurs.",
+        seoDescription:
+            "Développeur web PHP freelance à Nantes : conception d'applications, intégrations SI, maintenance et agilité pour entreprises ligériennes.",
+        keywords: [
+            "développeur PHP Nantes",
+            "freelance PHP Nantes",
+            "développeur web PHP Nantes",
+            "expert PHP Nantes",
+            "consultant PHP Nantes",
+        ],
+        highlights: [
+            {
+                title: "Approche produit centrée utilisateur",
+                description:
+                    "Co-conception avec vos équipes design et produit, tests utilisateurs et itérations rapides.",
+            },
+            {
+                title: "Interopérabilité SI",
+                description:
+                    "Connexion à vos plateformes IoT, ERP et solutions métiers pour une vision unifiée.",
+            },
+            {
+                title: "Qualité logicielle durable",
+                description:
+                    "Tests automatisés, pipeline CI/CD et documentation pour faire vivre vos projets dans le temps.",
+            },
+        ],
+        services: [
+            {
+                title: "Applications métier sur mesure",
+                description:
+                    "Architecture PHP modulaire, API et back-office adaptés à vos processus industriels.",
+            },
+            {
+                title: "Intégrations IoT",
+                description:
+                    "Collecte de données capteurs, traitement en temps réel et dashboards métiers.",
+            },
+            {
+                title: "Tierce maintenance applicative",
+                description:
+                    "Suivi quotidien, support et évolutions planifiées avec vos équipes nantaises.",
+            },
+        ],
+        results: [
+            {
+                value: "+25%",
+                label: "de productivité",
+                description: "grâce à la digitalisation d'un processus industriel nantais.",
+            },
+            {
+                value: "5 semaines",
+                label: "pour livrer un MVP",
+                description: "d'une plateforme IoT pilotée en PHP.",
+            },
+            {
+                value: "95%",
+                label: "de satisfaction",
+                description: "mesurée auprès des utilisateurs internes.",
+            },
+        ],
+        testimonials: [
+            {
+                quote:
+                    "Nous avions besoin d'un partenaire fiable pour notre plateforme IoT. Dylan a livré une solution PHP robuste et documentée.",
+                author: "Julie H.",
+                role: "COO, startup nantaise",
+            },
+        ],
+        faq: [
+            {
+                question: "Travaillez-vous avec les acteurs de la French Tech Nantes ?",
+                answer:
+                    "Oui, j'interviens régulièrement dans les incubateurs locaux et je m'adapte à vos méthodes produit.",
+            },
+            {
+                question: "Pouvez-vous reprendre notre legacy ?",
+                answer:
+                    "Je réalise un audit, sécurise la livraison continue puis planifie la refonte progressive de votre code PHP.",
+            },
+            {
+                question: "Proposez-vous un accompagnement long terme ?",
+                answer:
+                    "Oui, nous définissons ensemble un contrat de maintenance évolutive avec indicateurs de performance.",
+            },
+        ],
+    },
+    {
+        slug: "php-strasbourg",
+        technology: "PHP",
+        city: "Strasbourg",
+        heroTitle: "Développeur web PHP freelance à Strasbourg",
+        heroSubtitle: "Sécurisez vos projets PHP transfrontaliers",
+        heroDescription:
+            "Basé à Strasbourg, j'accompagne institutions européennes, entreprises industrielles et services transfrontaliers pour concevoir des solutions PHP fiables et multilingues.",
+        seoDescription:
+            "Développeur web PHP freelance à Strasbourg : portails institutionnels, intégrations transfrontalières, maintenance et support multilingue.",
+        keywords: [
+            "développeur PHP Strasbourg",
+            "freelance PHP Strasbourg",
+            "développeur web PHP Strasbourg",
+            "expert PHP Strasbourg",
+            "consultant PHP Strasbourg",
+        ],
+        highlights: [
+            {
+                title: "Expertise institutionnelle",
+                description:
+                    "Accessibilité, conformité RGAA et gestion multilingue pour vos portails publics.",
+            },
+            {
+                title: "Interopérabilité franco-allemande",
+                description:
+                    "Connecteurs SAP, échanges de données transfrontaliers et support bilingue FR/DE.",
+            },
+            {
+                title: "Sécurité renforcée",
+                description:
+                    "Gestion des identités, authentification forte et chiffrement de bout en bout.",
+            },
+        ],
+        services: [
+            {
+                title: "Portails institutionnels PHP",
+                description:
+                    "Architecture scalable, gestion de contenu et workflows de validation pour vos services publics.",
+            },
+            {
+                title: "Intégrations transfrontalières",
+                description:
+                    "Synchronisation des données avec vos partenaires allemands et suisses.",
+            },
+            {
+                title: "Support multilingue",
+                description:
+                    "Back-offices bilingues, traduction dynamique et assistance utilisateurs FR/DE.",
+            },
+        ],
+        results: [
+            {
+                value: "3 mois",
+                label: "pour livrer un portail",
+                description: "institutionnel multilingue conforme RGAA.",
+            },
+            {
+                value: "+40%",
+                label: "d'usagers satisfaits",
+                description: "après simplification des parcours en ligne.",
+            },
+            {
+                value: "0 faille",
+                label: "critique",
+                description: "après audit sécurité indépendant.",
+            },
+        ],
+        testimonials: [
+            {
+                quote:
+                    "Notre portail bilingue devait respecter des normes strictes. Dylan a livré une solution PHP robuste et sécurisée.",
+                author: "Helena K.",
+                role: "Responsable digital, institution strasbourgeoise",
+            },
+        ],
+        faq: [
+            {
+                question: "Pouvez-vous travailler avec nos équipes internationales ?",
+                answer:
+                    "Oui, j'anime les ateliers en français, anglais ou allemand et je m'adapte à vos fuseaux horaires.",
+            },
+            {
+                question: "Respectez-vous les normes d'accessibilité ?",
+                answer:
+                    "Je maîtrise RGAA/WCAG et je mets en place audits et corrections nécessaires.",
+            },
+            {
+                question: "Comment gérez-vous les données sensibles ?",
+                answer:
+                    "Chiffrement, anonymisation et politiques de rétention adaptées à vos exigences réglementaires.",
+            },
+        ],
+    },
+    {
+        slug: "php-montpellier",
+        technology: "PHP",
+        city: "Montpellier",
+        heroTitle: "Développeur web PHP freelance à Montpellier",
+        heroSubtitle: "Des solutions PHP agiles pour la French Tech Méditerranée",
+        heroDescription:
+            "Installé à Montpellier, j'aide les startups healthtech, edtech et smart city à livrer rapidement des applications PHP robustes et orientées croissance.",
+        seoDescription:
+            "Développeur web PHP freelance à Montpellier : MVP rapides, API performantes, maintenance et coaching pour startups et PME locales.",
+        keywords: [
+            "développeur PHP Montpellier",
+            "freelance PHP Montpellier",
+            "développeur web PHP Montpellier",
+            "expert PHP Montpellier",
+            "consultant PHP Montpellier",
+        ],
+        highlights: [
+            {
+                title: "Approche growth",
+                description:
+                    "Expérimentation rapide, instrumentation analytique et itérations hebdomadaires.",
+            },
+            {
+                title: "Stack moderne",
+                description:
+                    "Laravel, Symfony, API Platform, Next.js : des technologies adaptées à vos enjeux de scalabilité.",
+            },
+            {
+                title: "Accompagnement produit",
+                description:
+                    "Cadrage UX, priorisation et coaching pour vos product managers et développeurs.",
+            },
+        ],
+        services: [
+            {
+                title: "Lancement de MVP",
+                description:
+                    "Discovery, backlog, développement PHP et mise en production en un temps record.",
+            },
+            {
+                title: "API santé et smart city",
+                description:
+                    "Sécurité, conformité et intégrations temps réel avec vos partenaires.",
+            },
+            {
+                title: "Maintenance agile",
+                description:
+                    "Cycle d'itérations courtes, roadmap évolutive et suivi de vos KPIs.",
+            },
+        ],
+        results: [
+            {
+                value: "6 semaines",
+                label: "pour sortir un MVP",
+                description: "d'une startup healthtech montpelliéraine.",
+            },
+            {
+                value: "+50%",
+                label: "de rétention",
+                description: "après refonte UX et optimisation PHP.",
+            },
+            {
+                value: "2x",
+                label: "plus rapide",
+                description: "pour livrer de nouvelles fonctionnalités grâce à l'automatisation.",
+            },
+        ],
+        testimonials: [
+            {
+                quote:
+                    "Dylan a structuré notre roadmap et livré notre MVP PHP en un temps record. Nous avons convaincu nos investisseurs.",
+                author: "Amel B.",
+                role: "CEO, startup montpelliéraine",
+            },
+        ],
+        faq: [
+            {
+                question: "Intervenez-vous auprès des incubateurs locaux ?",
+                answer:
+                    "Oui, j'accompagne régulièrement les startups du BIC de Montpellier et des pépinières locales.",
+            },
+            {
+                question: "Pouvez-vous prendre en main notre stack existante ?",
+                answer:
+                    "Je réalise un audit, sécurise la CI/CD puis propose un plan d'itérations priorisées.",
+            },
+            {
+                question: "Proposez-vous des ateliers produit ?",
+                answer:
+                    "Oui, j'anime des workshops discovery, priorisation et métriques pour aligner toutes les équipes.",
+            },
+        ],
+    },
+    {
+        slug: "php-nice",
+        technology: "PHP",
+        city: "Nice",
+        heroTitle: "Développeur web PHP freelance à Nice",
+        heroSubtitle: "Des expériences PHP premium pour la Côte d'Azur",
+        heroDescription:
+            "À Nice, j'aide les acteurs du tourisme, de l'immobilier et des services premium à créer des plateformes PHP élégantes, performantes et multilingues.",
+        seoDescription:
+            "Développeur web PHP freelance à Nice : sites haut de gamme, intégrations CRM, API multilingues et maintenance pour entreprises azuréennes.",
+        keywords: [
+            "développeur PHP Nice",
+            "freelance PHP Nice",
+            "développeur web PHP Nice",
+            "expert PHP Nice",
+            "consultant PHP Nice",
+        ],
+        highlights: [
+            {
+                title: "Expérience client premium",
+                description:
+                    "Parcours haut de gamme, animation éditoriale multilingue et design sur mesure.",
+            },
+            {
+                title: "Ventes internationales",
+                description:
+                    "Gestion multi-devises, traduction dynamique et conformité fiscale pour vos clients étrangers.",
+            },
+            {
+                title: "Performance mobile",
+                description:
+                    "Optimisation Lighthouse, temps de chargement réduit et suivi des conversions mobile.",
+            },
+        ],
+        services: [
+            {
+                title: "Sites de réservation premium",
+                description:
+                    "Expériences personnalisées pour hôtels, villas et conciergeries de la Côte d'Azur.",
+            },
+            {
+                title: "CRM & marketing automation",
+                description:
+                    "Connecteurs HubSpot, Salesforce ou Brevo pour fidéliser vos clients haut de gamme.",
+            },
+            {
+                title: "Support multilingue",
+                description:
+                    "Back-office et front-end en plusieurs langues avec traduction assistée.",
+            },
+        ],
+        results: [
+            {
+                value: "+55%",
+                label: "de réservations directes",
+                description: "après la refonte d'un site hôtelier niçois.",
+            },
+            {
+                value: "4x",
+                label: "moins de tickets",
+                description: "grâce à un back-office PHP simplifié.",
+            },
+            {
+                value: "3 mois",
+                label: "pour rentabiliser",
+                description: "l'investissement sur une plateforme immobilière premium.",
+            },
+        ],
+        testimonials: [
+            {
+                quote:
+                    "Dylan a conçu une expérience digitale à la hauteur de nos clients internationaux. Nos réservations directes ont explosé.",
+                author: "Laura F.",
+                role: "Directrice marketing, groupe hôtelier niçois",
+            },
+        ],
+        faq: [
+            {
+                question: "Gérez-vous nos contenus multilingues ?",
+                answer:
+                    "Oui, je mets en place une architecture PHP multilingue avec workflows de traduction efficaces.",
+            },
+            {
+                question: "Pouvez-vous intégrer nos outils de conciergerie ?",
+                answer:
+                    "Je connecte votre plateforme PHP à vos CRM, channel managers et outils partenaires.",
+            },
+            {
+                question: "Proposez-vous un support pendant la haute saison ?",
+                answer:
+                    "Oui, je mets en place un dispositif de supervision et des astreintes pour sécuriser vos ventes.",
             },
         ],
     },


### PR DESCRIPTION
## Summary
- extend technology page schema to support city-specific landing content and structured data
- add targeted PHP landing pages for major French cities with localized messaging and offers
- adapt service schema metadata to reference the served city when available

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cee4faa7d48324a89e549236c4f2d6